### PR TITLE
Refine Supabase manager and unify API key handling

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -90,7 +90,7 @@ export const DOCUMENT_TYPES = {
 // Regex Patterns
 export const PATTERNS = {
   EMAIL: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
-  API_KEY: /^xbrl_[a-zA-Z0-9]{32}$/,
+  API_KEY: /^(?:[0-9a-fA-F-]{36}\.[A-Za-z0-9]{16,}|xbrl_[A-Za-z0-9]{16,})$/,
   COMPANY_ID: /^S[0-9A-Z]{7}$/,
   TICKER_CODE: /^\d{4}$/,
 } as const;

--- a/lib/infrastructure/health-check.ts
+++ b/lib/infrastructure/health-check.ts
@@ -80,7 +80,7 @@ export class HealthCheckService {
     const start = Date.now();
 
     try {
-      const result = await supabaseManager.executeQuery(
+      await supabaseManager.executeQuery(
         async (client) => {
           return await client
             .from('companies')

--- a/lib/security/apiKey.ts
+++ b/lib/security/apiKey.ts
@@ -1,64 +1,61 @@
-import crypto from 'crypto'
+/**
+ * Utilities for working with API keys in their public-facing form.
+ * The new key format is "<uuid>.<secret>" but we continue supporting
+ * legacy keys for migration purposes.
+ */
 
-const BASE62 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-
-function decodeSecret(raw: string): Buffer {
-  const base64Pattern = /^[A-Za-z0-9+/]+={0,2}$/
-  if (base64Pattern.test(raw) && raw.length % 4 === 0) {
-    try {
-      const decoded = Buffer.from(raw, 'base64')
-      if (decoded.toString('base64').replace(/=+$/, '') === raw.replace(/=+$/, '')) {
-        return decoded
-      }
-    } catch {
-      // fall through to utf-8
-    }
-  }
-  return Buffer.from(raw, 'utf-8')
-}
-
-// Lazy initialization of HMAC_SECRET to avoid build-time errors
-let HMAC_SECRET: Buffer | null = null
-
-function getHmacSecret(): Buffer {
-  if (HMAC_SECRET) return HMAC_SECRET
-
-  const rawSecret =
-    process.env.KEY_DERIVE_SECRET ??
-    process.env.KEY_PEPPER ??
-    process.env.API_KEY_SECRET
-
-  if (!rawSecret) {
-    throw new Error('KEY_DERIVE_SECRET (or KEY_PEPPER/API_KEY_SECRET) must be set for API key hashing')
-  }
-
-  HMAC_SECRET = decodeSecret(rawSecret)
-  return HMAC_SECRET
-}
-
-export function generateApiKey(prefix = 'xbrl_live', size = 32): string {
-  const bytes = crypto.randomBytes(size)
-  const chars = Array.from(bytes).map((b) => BASE62[b % BASE62.length]).join('')
-  return `${prefix}_${chars}`
-}
-
-export function hashApiKey(apiKey: string): string {
-  return crypto.createHmac('sha256', getHmacSecret()).update(apiKey).digest('hex')
-}
+const LEGACY_KEY_PATTERN = /^xbrl_[A-Za-z0-9]{16,}$/;
+const UUID_SECRET_PATTERN = /^[0-9a-fA-F-]{36}\.[A-Za-z0-9]{16,}$/;
 
 export function maskApiKey(apiKey: string): string {
-  if (!apiKey || apiKey.length < 12) return apiKey
-  const parts = apiKey.split('_')
-  const prefix = parts.length > 1 ? parts.slice(0, 2).join('_') : apiKey.slice(0, 8)
-  const suffix = apiKey.slice(-4)
-  return `${prefix}...${suffix}`
+  if (!apiKey) {
+    return '';
+  }
+
+  const [idPart, secretPart] = apiKey.split('.', 2);
+
+  if (!secretPart) {
+    // Legacy key style (no id separator)
+    if (apiKey.length <= 8) {
+      return apiKey;
+    }
+    return `${apiKey.slice(0, 4)}...${apiKey.slice(-4)}`;
+  }
+
+  const start = secretPart.slice(0, 4);
+  const end = secretPart.slice(-4);
+  return `${idPart}.${start}...${end}`;
 }
 
 export function extractApiKeyPrefix(apiKey: string): string {
-  const parts = apiKey.split('_')
-  return parts.length >= 2 ? `${parts[0]}_${parts[1]}` : parts[0]
+  if (!apiKey) return '';
+  const [idPart] = apiKey.split('.', 2);
+  return idPart ?? '';
 }
 
 export function extractApiKeySuffix(apiKey: string): string {
-  return apiKey.slice(-4)
+  if (!apiKey) return '';
+  const parts = apiKey.split('.', 2);
+  const secret = parts[1] ?? parts[0] ?? '';
+  return secret.slice(-4);
+}
+
+export function isValidApiKeyFormat(apiKey: string): boolean {
+  if (!apiKey) return false;
+  return UUID_SECRET_PATTERN.test(apiKey) || LEGACY_KEY_PATTERN.test(apiKey);
+}
+
+export function parseApiKey(apiKey: string): { id?: string; secret: string } | null {
+  if (!apiKey) return null;
+  const [idPart, secretPart] = apiKey.split('.', 2);
+
+  if (secretPart) {
+    return { id: idPart, secret: secretPart };
+  }
+
+  if (LEGACY_KEY_PATTERN.test(apiKey)) {
+    return { secret: apiKey };
+  }
+
+  return null;
 }

--- a/lib/services/company-service.ts
+++ b/lib/services/company-service.ts
@@ -118,16 +118,15 @@ export class CompanyService {
 
     try {
       // Get company details
-      const company = await supabaseManager.executeQuery<Company>(
-        async (client) => {
-          const result = await client
-            .from('companies')
-            .select('*')
-            .eq('id', id)
-            .single();
-          return result;
-        }
-      );
+      const { data: company } = await supabaseManager.executeQuery<{
+        data: Company | null;
+      }>(async (client) => {
+        return await client
+          .from('companies')
+          .select('*')
+          .eq('id', id)
+          .single();
+      });
 
       if (!company) {
         throw new AppError(
@@ -175,7 +174,9 @@ export class CompanyService {
     }
 
     try {
-      const files = await supabaseManager.executeQuery<any[]>(async (client) => {
+      const { data: files } = await supabaseManager.executeQuery<{
+        data: any[] | null;
+      }>(async (client) => {
         return await client
           .from('markdown_files_metadata')
           .select('*')
@@ -211,7 +212,9 @@ export class CompanyService {
 
     try {
       // Get file metadata
-      const metadata = await supabaseManager.executeQuery<any>(async (client) => {
+      const { data: metadata } = await supabaseManager.executeQuery<{
+        data: { storage_path: string | null } | null;
+      }>(async (client) => {
         return await client
           .from('markdown_files_metadata')
           .select('storage_path')

--- a/lib/supabase/api-key-utils.ts
+++ b/lib/supabase/api-key-utils.ts
@@ -1,19 +1,11 @@
 // APIキー関連のユーティリティ関数（サーバーサイド専用）
-import {
-  generateApiKey as coreGenerateApiKey,
-  hashApiKey,
-  maskApiKey as coreMaskApiKey
-} from '@/lib/security/apiKey'
+import { UnifiedAuthManager } from '@/lib/security/auth-manager'
+import { maskApiKey as coreMaskApiKey } from '@/lib/security/apiKey'
 
-// APIキー生成
-export function generateApiKey(prefix: string = 'xbrl', tier: string = 'free'): { apiKey: string; keyHash: string } {
-  const tierPrefix = tier === 'enterprise' ? 'ent' : tier.substring(0, 3)
-  const baseKey = coreGenerateApiKey(`${prefix}_${tierPrefix}`)
-  const keyHash = hashApiKey(baseKey)
-  return { apiKey: baseKey, keyHash }
+export async function createManagedApiKey(userId: string, name?: string) {
+  return UnifiedAuthManager.createApiKey(userId, name)
 }
 
-// APIキーのマスク表示
 export function maskApiKey(apiKey: string): string {
   return coreMaskApiKey(apiKey)
 }


### PR DESCRIPTION
## Summary
- ensure SupabaseManager.executeQuery returns full query responses so services can access metadata without duplicating database calls
- replace legacy API key generation and validation flows with UnifiedAuthManager across server actions and API endpoints while updating helper utilities and constants for the new id.secret format
- refresh the security middleware and rate limit helpers to forward authenticated headers and limit information, and align the server admin client with service-role requirements

## Testing
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68caabb3f80083258ecade38adfc649b