### PR TITLE
Potential fix for code scanning alert no. 125: Use of password hash with insufficient computational effort

### DIFF
--- a/lib/security/apiKey.ts
+++ b/lib/security/apiKey.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto'
+import bcrypt from 'bcrypt'
 
 const BASE62 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
@@ -43,7 +44,10 @@ export function generateApiKey(prefix = 'xbrl_live', size = 32): string {
 }
 
 export function hashApiKey(apiKey: string): string {
-  return crypto.createHmac('sha256', Uint8Array.from(getHmacSecret())).update(apiKey).digest('hex')
+  // Use bcrypt to hash API key with generated salt
+  // Cost factor of 12 is considered secure; can be adjusted via env/config if desired
+  const saltRounds = 12;
+  return bcrypt.hashSync(apiKey, saltRounds);
 }
 
 export function maskApiKey(apiKey: string): string {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "next": "^14.2.32",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zod": "^4.1.9"
+    "zod": "^4.1.9",
+    "bcrypt": "^6.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^30.1.2",


### PR DESCRIPTION
Potential fix for [https://github.com/ruisu2000p/xbrl-api-minimal/security/code-scanning/125](https://github.com/ruisu2000p/xbrl-api-minimal/security/code-scanning/125)

To fix the insecure hashing of API keys, we should replace the use of `crypto.createHmac('sha256', ...)` in `hashApiKey` with a computationally expensive password hashing function such as `bcrypt`. This protects against attackers efficiently brute-forcing API keys if the hashes are leaked. The fix involves updating the `hashApiKey` function in `lib/security/apiKey.ts` to use `bcrypt` for hashing the API key. We'll need to add an import for the `bcrypt` library, and ensure the hash is salted (in bcrypt, this is handled internally by `hashSync`). We'll continue to use a securely generated salt, either by using `bcrypt.genSaltSync()` or reusing an environment variable intended as a pepper for additional entropy. Only the `hashApiKey` function definition and relevant imports will change in `lib/security/apiKey.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
