### PR TITLE
Potential fix for code scanning alert no. 241: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/lib/security/unified-apikey.ts
+++ b/lib/security/unified-apikey.ts
@@ -33,10 +33,15 @@ export function generateApiKey(size = 43): string {
   const uuid = crypto.randomUUID();
 
   // Generate random secret
-  const bytes = crypto.randomBytes(size);
-  const chars = Array.from(bytes)
-    .map((b) => BASE62[b % BASE62.length])
-    .join('');
+  const charsArr: string[] = [];
+  while (charsArr.length < size) {
+    const byte = crypto.randomBytes(1)[0];
+    if (byte >= BASE62.length * Math.floor(256 / BASE62.length)) {
+      continue; // discard biased value
+    }
+    charsArr.push(BASE62[byte % BASE62.length]);
+  }
+  const chars = charsArr.join('');
 
   // 長い形式専用: xbrl_live_v1_{uuid}_{secret}
   return `xbrl_live_v1_${uuid}_${chars}`;


### PR DESCRIPTION
Potential fix for [https://github.com/ruisu2000p/xbrl-api-minimal/security/code-scanning/241](https://github.com/ruisu2000p/xbrl-api-minimal/security/code-scanning/241)

To fix the bias, we must avoid using `% BASE62.length` directly on random bytes. The best way is to use "rejection sampling": only accept random bytes if their value is within a range that maps evenly onto `BASE62.length`. Specifically, discard any bytes with a value >= 248, since 248 is the highest multiple of 62 less than 256 (62 * 4 = 248). This ensures that every character in `BASE62` is selected with the same probability. Alternatively, you could use a well-established library (e.g., `crypto-random-string`) for base62 generation, but if changing existing logic as little as possible is preferred, implement rejection sampling inline.

Edit the code in `lib/security/unified-apikey.ts`, in the `generateApiKey` function, specifically replacing lines 36-39. You'll need to generate random bytes until you have enough accepted values, mapping each accepted byte to a base62 character. No additional dependencies are strictly needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
